### PR TITLE
Temporary: test against cmaumet/nidmresults_spm_exporter_no_displaymap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ before_install:
  - git config --global user.name "TravisCI"
  - git config --global user.email "travis@dummy.com"
  # Create subtree nidm from main nidm repository
- - git remote add nidm https://github.com/incf-nidash/nidm.git
+ # - git remote add nidm https://github.com/incf-nidash/nidm.git
+ # Temporary: test against cmaumet/nidmresults_spm_exporter_no_displaymap
+ - git remote add nidm https://github.com/cmaumet/nidm.git
  - git fetch nidm
- - git subtree add --prefix nidm nidm/master --squash
+ # - git subtree add --prefix nidm nidm/master --squash
+ - git subtree add --prefix nidm nidm/nidmresults_spm_exporter_no_displaymap --squash


### PR DESCRIPTION
Hi @gllmflndn,

I have updated the examples as suggested:
 - No `DisplayMask` entity in example 001 (since no contrast masking was specified by the user)
 - A separate example 005 to test for contrast masking.

If you merge this PR, the tests will pass. 

If you want, we can also increase the test coverage (to contrast masking) using example005.