### PR TITLE
Test against cmaumet's branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ before_install:
  - git config --global user.name "TravisCI"
  - git config --global user.email "travis@dummy.com"
  # Create subtree nidm from main nidm repository
- - git remote add nidm https://github.com/incf-nidash/nidm.git
+ # - git remote add nidm https://github.com/incf-nidash/nidm.git
+ # - git fetch nidm
+ # - git subtree add --prefix nidm nidm/master --squash
+ - git remote add nidm https://github.com/cmaumet/nidm.git
  - git fetch nidm
- - git subtree add --prefix nidm nidm/master --squash
+ - git subtree add --prefix nidm nidm/spm_gt --squash


### PR DESCRIPTION
The Travis configuration file is modified so that the tests are performed against ground truth examples located in my branch `spm_gt` insteda of the `master` branch on the main nidm repository. 

This is a temporary update that will be rolled back in the future to allow for the inclusion of a few fixes in the ground truth before merging those changes on the main nidm repo.