### PR TITLE
Add ground truth version 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_install:
  - git fetch nidm
  - git subtree add --prefix nidm nidm/master --squash
  - git subtree add --prefix nidm_releases/1.0.0 nidm tags/NIDM-Results_1.0.0 --squash
+ - git subtree add --prefix nidm_releases/1.1.0 nidm tags/NIDM-Results_1.1.0 --squash


### PR DESCRIPTION
@gllmflndn: if you merge this PR, the ground truth for NIDM-Results 1.1.0 will be loaded and the tests should run at https://github.com/incf-nidash/nidm-results_spm/pull/20.