### PR TITLE
Try disabling topoFDR is jobman fails

### DIFF
--- a/nidm_export.m
+++ b/nidm_export.m
@@ -38,7 +38,20 @@ function nidm_export(data_path, out_path)
         
         result_batch{1}.spm.stats.results.spmmat = {fullfile(study_dir, 'SPM.mat')};
         result_batch{1}.spm.stats.results.print = 'nidm';    
-        spm_jobman('run', result_batch)
+        try
+            spm_jobman('run', result_batch)
+        catch ME
+            switch ME.identifier
+                case 'matlabbatch:run:jobfailederr'
+                    % Voxel-wise FDR requires topoFDR to be disabled
+                    global defaults;
+                    defaults.stats.topoFDR = 0;
+                    spm_jobman('run', result_batch)
+                    defaults.stats.topoFDR = 1;
+                otherwise
+                    rethrow(ME)
+            end
+        end
     end
     
     unzip('spm_0001.nidm.zip', 'nidm')


### PR DESCRIPTION
Hi @gllmflndn, 

This PR fixes https://github.com/incf-nidash/nidmresults-spm/issues/28 (i.e. topo FDR needs to be disabled for voxel-wise FDR threshold). If you merge this PR, https://github.com/incf-nidash/nidmresults-spm/pull/23 will be updated accordingly.

